### PR TITLE
[SPARK-51048][CORE] Support stop java spark context with exit code #49746

### DIFF
--- a/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/api/java/JavaSparkContext.scala
@@ -560,6 +560,8 @@ class JavaSparkContext(val sc: SparkContext) extends Closeable {
    * this method to stop SparkContext and pass client side correct exit code to scheduler backend.
    * Then scheduler backend should send the exit code to corresponding resource scheduler
    * to keep consistent.
+   * 
+   * This method is a direct call to the stop method from the underlying SparkContext.
    *
    * @param exitCode Specified exit code that will passed to scheduler backend in client mode.
    */


### PR DESCRIPTION
### What changes were proposed in this pull request?

Considering there is support to stop spark context with required exit code, This PR aims to use the same to add it to java spark context as well.

### Why are the changes needed?
Currently to use `stop(exitCode)` method for JavaSparkContext, user has to call `javaSparkContextsparkContext.stop(exitCode)`.
Post this PR user can directly do `javaSparkContextsparkContext.stop(exitCode)` to invoke same.


### Does this PR introduce _any_ user-facing change?

No, it introduces an extra method in JavaSparkContext class


### How was this patch tested?

This was tested in internal/production k8 cluster


### Was this patch authored or co-authored using generative AI tooling?

No
